### PR TITLE
Return requests.Response instead of bool for verbose debugging

### DIFF
--- a/examples/push_simple_event.py
+++ b/examples/push_simple_event.py
@@ -59,4 +59,6 @@ def push_simple_event_datetime(webthing_fqdn: str, property_uri: str, from_: dat
         [stimulus],
         description=description
     )
-    client.send_create_event_action(event)
+    resp = client.send_create_event_action(event)
+    if not resp.ok:
+        print(resp.text)

--- a/webthing/client.py
+++ b/webthing/client.py
@@ -34,6 +34,7 @@ class WebthingClient:
             self._ws_uri = f"wss://{self._webthing_fqdn}/websocket-stomp"
         else:
             self._ws_uri = f"ws://{self._webthing_fqdn}/websocket-stomp"
+        self._ws = StompWebsocket(self._ws_uri)
 
         if self._secure:
             self._webthing_url = f"https://{self._webthing_fqdn}"
@@ -46,7 +47,6 @@ class WebthingClient:
             callback(relative_uri, observation)
 
     def _ws_subscribe(self, relative_uri: str, callback: Callable[[str, str], None]) -> str:
-        self._ws = StompWebsocket(self._ws_uri)
         # Websocket expects "absolute" uri, make this transparent to the user
         self._ws.subscribe(f"/{relative_uri}", lambda destination, message: callback(destination.lstrip('/'), message))
 

--- a/webthing/client.py
+++ b/webthing/client.py
@@ -119,7 +119,7 @@ class WebthingClient:
             stream (bool, optional): If the event should be processed as realtime, only do this if near realtime. Defaults to False.
 
         Returns:
-            response: Response from the Web Thing (requests.Response)
+            response (requests.Response): Response from the Web Thing
         """
         action = CreateEventAction(None, event, stream)
         return self._send_action(action)
@@ -131,7 +131,7 @@ class WebthingClient:
             event (Event): Updated Event.
 
         Returns:
-            response: Response from the Web Thing (requests.Response)
+            response (requests.Response): Response from the Web Thing
         """
         action = UpdateEventAction(None, event)
         return self._send_action(action)
@@ -143,7 +143,7 @@ class WebthingClient:
             event (Event): Relative URI of the to be deleted event.
 
         Returns:
-            response: Response from the Web Thing (requests.Response)
+            response (requests.Response): Response from the Web Thing
         """
         action = DeleteEventAction(None, relative_uri)
         return self._send_action(action)

--- a/webthing/client.py
+++ b/webthing/client.py
@@ -1,5 +1,6 @@
 from typing import Callable, Dict, List, Tuple, Set
 import requests
+from requests import Response
 
 from .utils import get_relative_uri, datetime_utc_now
 from .stomp import StompWebsocket
@@ -33,7 +34,6 @@ class WebthingClient:
             self._ws_uri = f"wss://{self._webthing_fqdn}/websocket-stomp"
         else:
             self._ws_uri = f"ws://{self._webthing_fqdn}/websocket-stomp"
-        self._ws = StompWebsocket(self._ws_uri)
 
         if self._secure:
             self._webthing_url = f"https://{self._webthing_fqdn}"
@@ -46,6 +46,7 @@ class WebthingClient:
             callback(relative_uri, observation)
 
     def _ws_subscribe(self, relative_uri: str, callback: Callable[[str, str], None]) -> str:
+        self._ws = StompWebsocket(self._ws_uri)
         # Websocket expects "absolute" uri, make this transparent to the user
         self._ws.subscribe(f"/{relative_uri}", lambda destination, message: callback(destination.lstrip('/'), message))
 
@@ -105,15 +106,12 @@ class WebthingClient:
             self._ws_subscribe(self._ACTIONS_URI, self._process_action)
         self._action_callbacks.append((callback, type, filter_created))
 
-    def _send_action(self, action: Action) -> bool:
+    def _send_action(self, action: Action) -> Response:
         self._actions_created.add(action.hash())
         response = requests.post(f"{self._webthing_url}/{self._ACTIONS_URI}", json=action.get_value())
-        return response.ok
+        return response
 
-
-
-
-    def send_create_event_action(self, event: Event, stream: bool=False) -> bool:
+    def send_create_event_action(self, event: Event, stream: bool=False) -> Response:
         """Send a CreateEventAction for the given Event.
 
         Args:
@@ -121,32 +119,31 @@ class WebthingClient:
             stream (bool, optional): If the event should be processed as realtime, only do this if near realtime. Defaults to False.
 
         Returns:
-            bool: If the operation was successful.
+            response: Response from the Web Thing (requests.Response)
         """
         action = CreateEventAction(None, event, stream)
         return self._send_action(action)
 
-
-    def send_update_event_action(self, event: Event) -> bool:
+    def send_update_event_action(self, event: Event) -> Response:
         """Send a UpdateEventAction for the given Event.
 
         Args:
             event (Event): Updated Event.
 
         Returns:
-            bool: If the operation was successful.
+            response: Response from the Web Thing (requests.Response)
         """
         action = UpdateEventAction(None, event)
         return self._send_action(action)
 
-    def send_delete_event_action(self, relative_uri: str) -> bool:
+    def send_delete_event_action(self, relative_uri: str) -> Response:
         """Send a DeleteEventAction for the given Event relative URI.
 
         Args:
             event (Event): Relative URI of the to be deleted event.
 
         Returns:
-            bool: If the operation was successful.
+            response: Response from the Web Thing (requests.Response)
         """
         action = DeleteEventAction(None, relative_uri)
         return self._send_action(action)


### PR DESCRIPTION
Instead of returning a boolean after requests with the Web Thing, return the full response. Makes it easier to debug when something goes wrong.